### PR TITLE
Added ability to set max complexity argument for flake8.

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -40,6 +40,10 @@ If you want to change the max line length for PEP8:
 
     let g:flake8_max_line_length=99
 
+To set the maximum [McCabe complexity](https://en.wikipedia.org/wiki/Cyclomatic_complexity) before a warning is issued:
+
+    let g:flake8_max_complexity=10
+
 To cutomize the location of your flake8 binary, set `g:flake8_cmd`:
 
     let g:flake8_cmd="/opt/strangebin/flake8000"

--- a/ftplugin/python_flake8.vim
+++ b/ftplugin/python_flake8.vim
@@ -27,6 +27,11 @@ if exists("g:flake8_max_line_length")
     let s:flake8_max_line_length=" --max-line-length=".g:flake8_max_line_length
 endif
 
+let s:flake8_max_complexity=""
+if exists("g:flake8_max_complexity")
+    let s:flake8_max_complexity=" --max-complexity=".g:flake8_max_complexity
+endif
+
 if !exists("*Flake8()")
     function Flake8()
         if !executable(s:flake8_cmd)
@@ -48,7 +53,7 @@ if !exists("*Flake8()")
 
         " perform the grep itself
         let &grepformat="%f:%l:%c: %m\,%f:%l: %m"
-        let &grepprg=s:flake8_cmd.s:flake8_ignores.s:flake8_max_line_length
+        let &grepprg=s:flake8_cmd.s:flake8_ignores.s:flake8_max_line_length.s:flake8_max_complexity
         silent! grep! %
 
         " restore grep settings


### PR DESCRIPTION
I like the idea of having flake8 check for code that is [too complex](https://en.wikipedia.org/wiki/Cyclomatic_complexity), but there was no way to set this option in the vim plugin. I went ahead and added it as `g:flake8_max_complexity`.
