### PR TITLE
add exclude to flake8 options

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -47,6 +47,10 @@ To ignore errors, in your .vimrc:
 
     let g:flake8_ignore="E501,W293"
 
+To exclude files and/or folders, in your .vimrc:
+
+    let g:flake8_exclude=".svn,CVS,.bzr,.hg,.git,__pycache"
+
 If you want to change the max line length for PEP8:
 
     let g:flake8_max_line_length=99

--- a/autoload/flake8.vim
+++ b/autoload/flake8.vim
@@ -49,6 +49,7 @@ function! s:Setup()  " {{{
     " flake8 stuff
     call s:DeclareOption('flake8_builtins',        ' --builtins=',        '')
     call s:DeclareOption('flake8_ignore',          ' --ignore=',          '')
+    call s:DeclareOption('flake8_exclude',         ' --exclude=',         '')
     call s:DeclareOption('flake8_max_line_length', ' --max-line-length=', '')
     call s:DeclareOption('flake8_max_complexity',  ' --max-complexity=',  '')
     " quickfix
@@ -116,7 +117,12 @@ function! s:Flake8()  " {{{
 
     " perform the grep itself
     let &grepformat="%f:%l:%c: %m\,%f:%l: %m"
-    let &grepprg=s:flake8_cmd.s:flake8_builtins.s:flake8_ignore.s:flake8_max_line_length.s:flake8_max_complexity
+    let &grepprg=s:flake8_cmd.
+          \ s:flake8_builtins. 
+          \ s:flake8_ignore. 
+          \ s:flake8_exclude. 
+          \ s:flake8_max_line_length. 
+          \ s:flake8_max_complexity
     silent! grep! "%"
 
     " restore grep settings


### PR DESCRIPTION
allows user to exclude files/folders from .vimrc

`let g:flake8_exclude=".svn,CVS,.bzr,.hg,.git,__pycache"`
