### PR TITLE
Map F7/F8 to Python 2/3 flake8

### DIFF
--- a/autoload/flake8.vim
+++ b/autoload/flake8.vim
@@ -75,7 +75,7 @@ function! s:Setup()  " {{{
     "" read options
 
     " flake8 command
-    call s:DeclareOption('flake8_cmd', '', '"/usr/bin/flake8"')
+    call s:DeclareOption('flake8_cmd', '', '"'.system('which flake8 | xargs echo -n').'"')
     " quickfix
     call s:DeclareOption('flake8_quickfix_location', '', '"belowright"')
     call s:DeclareOption('flake8_quickfix_height', '', 5)

--- a/autoload/flake8.vim
+++ b/autoload/flake8.vim
@@ -10,8 +10,13 @@ set cpo&vim
 
 "" ** external ** {{{
 
+function! flake8#Flake3()
+    call s:Flake8("python3")
+    call s:Warnings()
+endfunction
+
 function! flake8#Flake8()
-    call s:Flake8()
+    call s:Flake8("python2")
     call s:Warnings()
 endfunction
 
@@ -70,7 +75,7 @@ function! s:Setup()  " {{{
     "" read options
 
     " flake8 command
-    call s:DeclareOption('flake8_cmd', '', '"flake8"')
+    call s:DeclareOption('flake8_cmd', '', '"/usr/bin/flake8"')
     " quickfix
     call s:DeclareOption('flake8_quickfix_location', '', '"belowright"')
     call s:DeclareOption('flake8_quickfix_height', '', 5)
@@ -105,7 +110,7 @@ endfunction  " }}}
 
 "" do flake8
 
-function! s:Flake8()  " {{{
+function! s:Flake8(pyversion)  " {{{
     " read config
     call s:Setup()
 
@@ -137,7 +142,7 @@ function! s:Flake8()  " {{{
 
     " perform the grep itself
     let &grepformat="%f:%l:%c: %m\,%f:%l: %m"
-    let &grepprg=s:flake8_cmd
+    let &grepprg=a:pyversion.' '.s:flake8_cmd
     silent! grep! "%"
 
     " restore grep settings

--- a/ftplugin/python_flake8.vim
+++ b/ftplugin/python_flake8.vim
@@ -48,6 +48,9 @@ if !exists("no_plugin_maps") && !exists("no_flake8_maps")
     if !hasmapto('Flake8(') && !hasmapto('flake8#Flake8(')
         noremap <buffer> <F7> :call flake8#Flake8()<CR>
     endif
+    if !hasmapto('Flake3(') && !hasmapto('flake8#Flake3(')
+        noremap <buffer> <F8> :call flake8#Flake3()<CR>
+    endif
 endif
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
The behavior of flake8 changes a bit depending on whether it's called by Python 2 or 3. This allows users to map both versions, by default to F7 and F8.

Never edited vim scripts before, so ended up using `system` and `echo -n` to get the proper location of flake8. Open to cleaning this up if this is useful to anyone else.