### PR TITLE
Check if s:markerdata is defined

### DIFF
--- a/autoload/flake8.vim
+++ b/autoload/flake8.vim
@@ -234,13 +234,15 @@ function! s:UnplaceMarkers()  " {{{
         unlet s:signids
     endif
     " file markers
-    for l:val in values(s:markerdata)
-        if has_key(l:val, 'matchid')
-            call matchdelete(l:val.matchid)
-            unlet l:val.matchid
-            unlet l:val.matchstr
-        endif
-    endfor
+    if exists('s:markerdata')
+        for l:val in values(s:markerdata)
+            if has_key(l:val, 'matchid')
+                call matchdelete(l:val.matchid)
+                unlet l:val.matchid
+                unlet l:val.matchstr
+            endif
+        endfor
+    endif
 endfunction  " }}}
 
 "" }}}


### PR DESCRIPTION
I have a single mapping that calls both :noh and Flake8UnplaceMarkers. However, Flake8UnplaceMarkers fails if Flake8 has not already been called since s:markerdata is not defined. This seems like an oversight in the code since it currently checks if s:signids is defined before removing gutter marks, so it seems natural to also check if there is marker data before removing markers.