### PR TITLE
explain how to install with vim 8's pack feature

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -12,9 +12,19 @@ a static syntax and style checker for Python source code.  It supersedes both
 
 Installation
 ------------
-Use [vim-pathogen](https://github.com/tpope/vim-pathogen) if you're not using
-it already.  Make sure you've installed the
-[flake8](https://pypi.python.org/pypi/flake8/) package.  Then, simply put the
+
+Make sure you've installed the
+[flake8](https://pypi.python.org/pypi/flake8/) package.
+
+If you use vim >= 8, install this plugin with:
+```
+mkdir -p ~/.vim/pack/flake8/start/
+cd ~/.vim/pack/flake8/start/
+git clone https://github.com/nvie/vim-flake8.git
+```
+
+Otherwise, install [vim-pathogen](https://github.com/tpope/vim-pathogen)
+if you're not using it already. Then, simply put the
 contents of this repository in your `~/.vim/bundle` directory.
 
 Usage


### PR DESCRIPTION
Hi there

Since vim now supports packs, pathogen is not necessary anymore for installation. This PR just adds instructions for deploying the plugin without pathogen.