### PR TITLE
Adds option to show Error Message of line under cursor

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -104,6 +104,12 @@ To customize the colors used for markers, define the highlight groups, `Flake8_E
     highlight link Flake8_Naming     WarningMsg
     highlight link Flake8_PyFlake    WarningMsg
 
+To show the error message of the current line in the ruler, call `flake8#ShowError()`:
+
+    " add binding to call the function
+    nnoremap <C-K> :call flake8#Flake8ShowError()<cr>
+    
+
 Tips
 ----
 A tip might be to run the Flake8 check every time you write a Python file, to

--- a/autoload/flake8.vim
+++ b/autoload/flake8.vim
@@ -31,7 +31,7 @@ endfunction
 "" warnings 
 
 let s:displayed_warnings = 0
-function! s:Warnings()
+function s:Warnings()
   if !s:displayed_warnings
     let l:show_website_url = 0
 
@@ -170,7 +170,7 @@ function! s:Flake8()  " {{{
     let l:has_results=results != []
     if l:has_results
 	" save line number of each error message	
-        for result in a:results:
+        for result in l:results:
             s:resultDict[result.lnum] = result.text
 
         " markers

--- a/autoload/flake8.vim
+++ b/autoload/flake8.vim
@@ -199,10 +199,6 @@ function! s:Flake8()  " {{{
 endfunction  " }}}
 
 
-function! s:MakeMap(results)  " {{{
-    for result in a:results
-    endfor
-endfunction  " }}}
 
 "" markers
 function! s:PlaceMarkers(results)  " {{{

--- a/autoload/flake8.vim
+++ b/autoload/flake8.vim
@@ -20,7 +20,7 @@ function! flake8#Flake8UnplaceMarkers()
     call s:Warnings()
 endfunction
 
-function! flake8#ShowErrorMessage()
+function! flake8#Flake8ShowError()
     call s:ShowErrorMessage()
 endfunction
 
@@ -106,8 +106,6 @@ function! s:Setup()  " {{{
     let s:markerdata['C'].marker = s:flake8_complexity_marker
     let s:markerdata['N'].marker = s:flake8_naming_marker
 
-
-
 endfunction  " }}}
 
 "" do flake8
@@ -170,8 +168,10 @@ function! s:Flake8()  " {{{
     let l:has_results=results != []
     if l:has_results
 	" save line number of each error message	
-        for result in l:results:
-            s:resultDict[result.lnum] = result.text
+        for result in l:results
+	    let linenum = result.lnum
+            let s:resultDict[linenum] = result.text
+	endfor
 
         " markers
         if !s:flake8_show_in_gutter == 0 || !s:flake8_show_in_file == 0
@@ -196,6 +196,12 @@ function! s:Flake8()  " {{{
     else
         echon "Flake8 found issues"
     endif
+endfunction  " }}}
+
+
+function! s:MakeMap(results)  " {{{
+    for result in a:results
+    endfor
 endfunction  " }}}
 
 "" markers
@@ -274,8 +280,8 @@ function! s:ShowErrorMessage()  " {{{
 
     " if there is a message on the current line,
     " then echo it 
-    if has_key(s:matchDict, s:cursorPos[1])
-	let l:errorText = get(s:matchDict, l:cursorPos[1]) 
+    if has_key(s:resultDict, l:cursorPos[1])
+	let l:errorText = get(s:resultDict, l:cursorPos[1]) 
 	echo strpart(l:errorText, 0, &columns-1)
 	let b:showing_message = 1
     endif


### PR DESCRIPTION
Fixes #80 
This PR adds a function **flake8#ShowError()** which shows the Error message of the line under the cursor. 
The user can map this to any key like so:
`nnoremap <C-K> :call flake8#Flake8ShowError()<cr>`
