### PR TITLE
Adds function to Jump to Next / Prev errors

### DIFF
--- a/autoload/flake8.vim
+++ b/autoload/flake8.vim
@@ -24,6 +24,10 @@ function! flake8#Flake8ShowError()
     call s:ShowErrorMessage()
 endfunction
 
+function! flake8#Flake8NextError()
+    call s:JumpNextError()
+endfunction
+
 "" }}}
 
 "" ** internal ** {{{
@@ -270,6 +274,23 @@ function! s:UnplaceMarkers()  " {{{
             unlet l:val.matchstr
         endif
     endfor
+endfunction  " }}}
+
+function! s:JumpNextError()  " {{{
+    let l:cursorLine = getpos(".")[1]
+    if !exists('s:resultDict')
+	return
+    endif
+
+    let l:lineList = keys(s:resultDict)
+
+    for line in lineList
+        if line	> l:cursorLine
+	    call cursor(line)
+	    call s:ShowErrorMessage()
+	endif
+    endfor
+
 endfunction  " }}}
 
 function! s:ShowErrorMessage()  " {{{

--- a/autoload/flake8.vim
+++ b/autoload/flake8.vim
@@ -28,6 +28,10 @@ function! flake8#Flake8NextError()
     call s:JumpNextError()
 endfunction
 
+function! flake8#Flake8PrevError()
+    call s:JumpPrevError()
+endfunction
+
 "" }}}
 
 "" ** internal ** {{{
@@ -276,23 +280,6 @@ function! s:UnplaceMarkers()  " {{{
     endfor
 endfunction  " }}}
 
-function! s:JumpNextError()  " {{{
-    let l:cursorLine = getpos(".")[1]
-    if !exists('s:resultDict')
-	return
-    endif
-
-    let l:lineList = keys(s:resultDict)
-
-    for line in lineList
-        if line	> l:cursorLine
-	    call cursor(line)
-	    call s:ShowErrorMessage()
-	endif
-    endfor
-
-endfunction  " }}}
-
 function! s:ShowErrorMessage()  " {{{
     let l:cursorPos = getpos(".")
     if !exists('s:resultDict')
@@ -313,6 +300,57 @@ function! s:ShowErrorMessage()  " {{{
 	echo
 	let b:showing_message = 0
     endif
+endfunction  " }}}
+
+function! s:JumpNextError()  " {{{
+    let l:cursorLine = getpos(".")[1]
+    if !exists('s:resultDict')
+	return
+    endif
+
+    " Convert list of strings to ints
+    let l:lineList = []
+    for line in keys(s:resultDict)
+	call insert(l:lineList, line+0)
+    endfor
+
+    let l:sortedLineList = sort(l:lineList, 'n')
+    for line in l:sortedLineList
+	let l:line_int = line + 0
+        if line	> l:cursorLine
+	    call cursor(line, 1)
+	    call s:ShowErrorMessage()
+	    return
+	endif
+    endfor
+    call cursor(l:cursorLine, 1)
+    echo "Reached last error!"
+
+endfunction  " }}}
+
+function! s:JumpPrevError()  " {{{
+    let l:cursorLine = getpos(".")[1]
+    if !exists('s:resultDict')
+	return
+    endif
+
+    " Convert list of strings to ints
+    let l:lineList = []
+    for line in keys(s:resultDict)
+	call insert(l:lineList, line+0)
+    endfor
+
+    let l:sortedLineList = reverse(sort(l:lineList, 'n'))
+    for line in l:sortedLineList
+	let l:line_int = line + 0
+        if line	< l:cursorLine
+	    call cursor(line, 1)
+	    call s:ShowErrorMessage()
+	    return
+	endif
+    endfor
+    call cursor(l:cursorLine, 1)
+    echo "Reached first error!"
 
 endfunction  " }}}
 

--- a/autoload/flake8.vim
+++ b/autoload/flake8.vim
@@ -207,11 +207,6 @@ function! s:Flake8()  " {{{
 endfunction  " }}}
 
 
-function! s:MakeMap(results)  " {{{
-    for result in a:results
-    endfor
-endfunction  " }}}
-
 "" markers
 function! s:PlaceMarkers(results)  " {{{
     " in gutter?


### PR DESCRIPTION
Fixes #82 
Exposes functions
 `flake8#Flake8NextError()` and `flake8#Flake8PrevError()` 
that can be called to move the cursor to the next / prev error in the current file and also Show the error message under the cursor
This pull request depends on #81 for showing the error message of the current line.
