### PR TITLE
ignore `flake8 --count` lines

### DIFF
--- a/autoload/flake8.vim
+++ b/autoload/flake8.vim
@@ -146,7 +146,7 @@ function! s:Flake8()  " {{{
     set t_te=
 
     " perform the grep itself
-    let &grepformat="%f:%l:%c: %m\,%f:%l: %m"
+    let &grepformat="%f:%l:%c: %m\,%f:%l: %m,%-G%\\d"
     let &grepprg=s:flake8_cmd
     silent! grep! "%"
     " close any existing cwindows,


### PR DESCRIPTION
Fixes #68

If flake8 is configured to run with `--count` (`count = True` in a config file) it will print an extra line that contains the number of errors found.

If there are no errors, this causes vim-flake8 to open a quickfix window containing `|| 0`, since the `0` line does not match any of the expected patterns. If there are any errors, this causes vim-flake8 to open a quickfix window containing an extra `|| <count>` line at the end.

This PR just updates the expected patterns to ignore flake8 output lines that only contain a number

---

To reproduce the issue:

example `flake8` with count output:
```
$ ls
setup.cfg  test.py
$ cat test.py
print("hello world")
$ cat setup.cfg
[flake8]
count = True
$ flake8 test.py
0
```

vim-flake8 with no errors
![Screen Shot 2021-07-06 at 3 47 27 PM](https://user-images.githubusercontent.com/651988/124555651-4cbc9f00-de72-11eb-8be5-d6c7a032f640.png)

vim-flake8 with errors
![Screen Shot 2021-07-06 at 3 48 24 PM](https://user-images.githubusercontent.com/651988/124555743-6827aa00-de72-11eb-9273-98848161da46.png)
