### PR TITLE
New user options

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -70,6 +70,12 @@ To customize whether the quickfix window opens, set `g:flake8_show_quickfix`:
     let g:flake8_show_quickfix=0  " don't show
     let g:flake8_show_quickfix=1  " show (default)
 
+To customize wheather the quickfix window stays open even when no errors are found, set
+`g:flake8_always_visible`:
+
+    let g:flake8_always_visible=0   " don't show quickfix window if no errors (default)
+    let g:flake8_always_visible=1   " show quickfix window even if no errors
+
 To customize whether the show signs in the gutter, set `g:flake8_show_in_gutter`:
 
     let g:flake8_show_in_gutter=0  " don't show (default)
@@ -109,6 +115,14 @@ To show the error message of the current line in the ruler, call `flake8#ShowErr
     " add binding to call the function
     nnoremap <C-K> :call flake8#Flake8ShowError()<cr>
     
+To disable the auto-save option (vim `update`) while running `:flake8#Flake8()` use the
+`g:flake8_auto_update` option. This can be disabled to prevent auto-saving a file if the
+Flake8 command is run as part of an `autocmd` for instance. This will prevent overwritting
+of the file. Note however, that flake8 will be run on the existing file on the file system,
+and not the current buffer when this option is disabled:
+
+    let g:flake8_auto_update=0  " Disable auto-save when running Flake8
+    let g:flake8_auto_update=1  " Enable auto-save when running Flake8 (default)
 
 Tips
 ----

--- a/autoload/flake8.vim
+++ b/autoload/flake8.vim
@@ -79,7 +79,7 @@ function! s:Setup()  " {{{
     call s:DeclareOption('flake8_quickfix_location', '', '"belowright"')
     call s:DeclareOption('flake8_quickfix_height', '', 5)
     call s:DeclareOption('flake8_show_quickfix', '', 1)
-	call s:DeclareOption('flake8_always_visible', '', 0)
+    call s:DeclareOption('flake8_always_visible', '', 0)
     " markers to show
     call s:DeclareOption('flake8_show_in_gutter', '',   0)
     call s:DeclareOption('flake8_show_in_file', '',   0)
@@ -90,8 +90,8 @@ function! s:Setup()  " {{{
     call s:DeclareOption('flake8_pyflake_marker', '', '"F>"')
     call s:DeclareOption('flake8_complexity_marker', '', '"C>"')
     call s:DeclareOption('flake8_naming_marker', '', '"N>"')
-	" other configuration options
-	call s:DeclareOption('flake8_auto_update', '', 1)
+    " other configuration options
+    call s:DeclareOption('flake8_auto_update', '', 1)
 
     "" setup markerdata
 
@@ -170,28 +170,28 @@ function! s:Flake8()  " {{{
     let l:results=getqflist()
     let l:has_results=results != []
 	if l:has_results || s:flake8_always_visible
-		" save line number of each error message
-		for result in l:results
-			let linenum = result.lnum
-			let s:resultDict[linenum] = result.text
-		endfor
+	" save line number of each error message	
+        for result in l:results
+	        let linenum = result.lnum
+            let s:resultDict[linenum] = result.text
+	    endfor
 
-		" markers
-		if !s:flake8_show_in_gutter == 0 || !s:flake8_show_in_file == 0
-			call s:PlaceMarkers(l:results)
-		endif
-		" quickfix
-		if !s:flake8_show_quickfix == 0
-			" open cwindow
-			execute s:flake8_quickfix_location." copen".s:flake8_quickfix_height
-			setlocal wrap
-			nnoremap <buffer> <silent> c :cclose<CR>
-			nnoremap <buffer> <silent> q :cclose<CR>
-		endif
-	endif
+        " markers
+        if !s:flake8_show_in_gutter == 0 || !s:flake8_show_in_file == 0
+            call s:PlaceMarkers(l:results)
+        endif
+        " quickfix
+        if !s:flake8_show_quickfix == 0
+            " open cwindow
+            execute s:flake8_quickfix_location." copen".s:flake8_quickfix_height
+            setlocal wrap
+            nnoremap <buffer> <silent> c :cclose<CR>
+            nnoremap <buffer> <silent> q :cclose<CR>
+        endif
+    endif
 
-	set nolazyredraw
-	redraw!
+    set nolazyredraw
+    redraw!
 
     " Show status
     if l:has_results == 0

--- a/autoload/flake8.vim
+++ b/autoload/flake8.vim
@@ -169,7 +169,7 @@ function! s:Flake8()  " {{{
 
     let l:results=getqflist()
     let l:has_results=results != []
-	if l:has_results || s:flake8_always_visible
+    if l:has_results || s:flake8_always_visible
 	" save line number of each error message	
         for result in l:results
 	        let linenum = result.lnum

--- a/autoload/flake8.vim
+++ b/autoload/flake8.vim
@@ -79,6 +79,7 @@ function! s:Setup()  " {{{
     call s:DeclareOption('flake8_quickfix_location', '', '"belowright"')
     call s:DeclareOption('flake8_quickfix_height', '', 5)
     call s:DeclareOption('flake8_show_quickfix', '', 1)
+	call s:DeclareOption('flake8_always_visible', '', 0)
     " markers to show
     call s:DeclareOption('flake8_show_in_gutter', '',   0)
     call s:DeclareOption('flake8_show_in_file', '',   0)
@@ -89,6 +90,8 @@ function! s:Setup()  " {{{
     call s:DeclareOption('flake8_pyflake_marker', '', '"F>"')
     call s:DeclareOption('flake8_complexity_marker', '', '"C>"')
     call s:DeclareOption('flake8_naming_marker', '', '"N>"')
+	" other configuration options
+	call s:DeclareOption('flake8_auto_update', '', 1)
 
     "" setup markerdata
 
@@ -134,7 +137,7 @@ function! s:Flake8()  " {{{
     let l:old_t_te=&t_te
 
     " write any changes before continuing
-    if &readonly == 0
+    if &readonly == 0 && s:flake8_auto_update
         update
     endif
 
@@ -166,29 +169,29 @@ function! s:Flake8()  " {{{
 
     let l:results=getqflist()
     let l:has_results=results != []
-    if l:has_results
-	" save line number of each error message	
-        for result in l:results
-	    let linenum = result.lnum
-            let s:resultDict[linenum] = result.text
-	endfor
+	if l:has_results || s:flake8_always_visible
+		" save line number of each error message
+		for result in l:results
+			let linenum = result.lnum
+			let s:resultDict[linenum] = result.text
+		endfor
 
-        " markers
-        if !s:flake8_show_in_gutter == 0 || !s:flake8_show_in_file == 0
-            call s:PlaceMarkers(l:results)
-        endif
-        " quickfix
-        if !s:flake8_show_quickfix == 0
-            " open cwindow
-            execute s:flake8_quickfix_location." copen".s:flake8_quickfix_height
-            setlocal wrap
-            nnoremap <buffer> <silent> c :cclose<CR>
-            nnoremap <buffer> <silent> q :cclose<CR>
-        endif
-    endif
+		" markers
+		if !s:flake8_show_in_gutter == 0 || !s:flake8_show_in_file == 0
+			call s:PlaceMarkers(l:results)
+		endif
+		" quickfix
+		if !s:flake8_show_quickfix == 0
+			" open cwindow
+			execute s:flake8_quickfix_location." copen".s:flake8_quickfix_height
+			setlocal wrap
+			nnoremap <buffer> <silent> c :cclose<CR>
+			nnoremap <buffer> <silent> q :cclose<CR>
+		endif
+	endif
 
-    set nolazyredraw
-    redraw!
+	set nolazyredraw
+	redraw!
 
     " Show status
     if l:has_results == 0


### PR DESCRIPTION
The following options are useful when vim is configured to run `:Flake8`
when first opening a file with something like the following:

```vim
autocmd BufReadPost *.py call flake8#Flake8()
```

### Always Visible Option `g:flake8_always_visible`
This option will always show the quickfix window even if no errors
are visible. This makes is more clear to see that there are no errors
seen in the file when setting flake8 to run when first opening a file.
This is especially true if there are other plugins that are logged to
`echon` which may load or run after flake8.

### Auto-Update Option `g:flake8_auto_update`
This is to fix an issue when attempting to run `:Flake8` on a file that
does not yet exist on the file system. Currently, when `:Flake8` is run
it will trigger an `update` which forcefully writes out the file before
running flake8 on it.

This is causing an issue when setting flake8 to run when a file is
opened. This forces a new file to be created when it may not be intended.
A specific use-case would be when using git to view a file from another
branch. This can be done via the following (setup via a git alias):

```
git show some_branch:./test.py | vim -c "file some_branch:test.py" -c
"doautocmd BufRead test.py -"
```

This allows vim to open the contents of the file from stdin, thereby
reading the contents of the `git show` output. If this is done, then
the local copy of the file would be overwritten which could be
unintended and lead to lost changes.

Ideally the `update` should not be performed automatically, but that
would change the behavior for existing users of this plugin, however
adding thie config option will at least allow for better handling of
this.