### PR TITLE
Add Flake command

### DIFF
--- a/ftplugin/python_flake8.vim
+++ b/ftplugin/python_flake8.vim
@@ -50,6 +50,8 @@ if !exists("no_plugin_maps") && !exists("no_flake8_maps")
     endif
 endif
 
+command! Flake :call flake8#Flake8()
+
 let &cpo = s:save_cpo
 unlet s:save_cpo
 


### PR DESCRIPTION
@nvie, please check this PR. It closes #75 issue. I don't know VimScript but this command declaration seems to work in my `~/.vimrc`:

```vim
set number relativenumber
set background=light

call plug#begin()
Plug 'davidhalter/jedi-vim'
Plug 'nvie/vim-flake8'
Plug 'itspriddle/vim-shellcheck'
Plug 'alx741/vinfo'
Plug 'morhetz/gruvbox'
call plug#end()

if (empty($TMUX))
  if (has("nvim"))
    "For Neovim 0.1.3 and 0.1.4 < https://github.com/neovim/neovim/pull/2198 >
    let $NVIM_TUI_ENABLE_TRUE_COLOR=1
  endif
  "For Neovim > 0.1.5 and Vim > patch 7.4.1799 < https://github.com/vim/vim/commit/61be73bb0f965a895bfb064ea3e55476ac175162 >
  "Based on Vim patch 7.4.1770 (`guicolors` option) < https://github.com/vim/vim/commit/8a633e3427b47286869aa4b96f2bfc1fe65b25cd >
  " < https://github.com/neovim/neovim/wiki/Following-HEAD#20160511 >
  if (has("termguicolors"))
    set termguicolors
  endif
endif

colorscheme gruvbox
command! Flake :call flake8#Flake8()
```